### PR TITLE
refactor: migrate ipfs/tar-utils

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/ipfs/libkubo
+
+go 1.19
+
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/utils/tar/extractor.go
+++ b/utils/tar/extractor.go
@@ -1,0 +1,327 @@
+package tar
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	fp "path/filepath"
+	"strings"
+)
+
+var errTraverseSymlink = errors.New("cannot traverse symlinks")
+var errInvalidRoot = errors.New("tar has invalid root")
+var errInvalidRootMultipleRoots = fmt.Errorf("contains more than one root or the root directory is not the first entry : %w", errInvalidRoot)
+
+// Extractor is used for extracting tar files to a filesystem.
+//
+// The Extractor can only extract tar files containing files, directories and symlinks. Additionally, the tar files must
+// either have a single file, or symlink in them, or must have all of its objects inside of a single root directory
+// object.
+//
+// If the tar file contains a single file/symlink then it will try and extract it with semantics similar to Linux's
+// `cp`. In particular, the name of the extracted file/symlink will match the extraction path. If the extraction path
+// is a directory then it will extract into the directory using its original name.
+//
+// Overwriting: Extraction of files and symlinks will result in overwriting the existing objects with the same name
+// when possible (i.e. other files, symlinks, and empty directories).
+type Extractor struct {
+	Path     string
+	Progress func(int64) int64
+}
+
+// Extract extracts a tar file to the file system. See the Extractor for more information on the limitations on the
+// tar files that can be extracted.
+func (te *Extractor) Extract(reader io.Reader) error {
+	if isNullDevice(te.Path) {
+		return nil
+	}
+
+	tarReader := tar.NewReader(reader)
+
+	var firstObjectWasDir bool
+
+	header, err := tarReader.Next()
+	if err != nil && err != io.EOF {
+		return err
+	}
+	if header == nil || err == io.EOF {
+		return fmt.Errorf("empty tar file")
+	}
+
+	// Specially handle the first entry assuming it is a single root object (e.g. root directory, single file,
+	// or single symlink)
+
+	// track what the root tar path is so we can ensure that all other entries are below the root
+	if strings.Contains(header.Name, "/") {
+		return fmt.Errorf("root name contains multiple components : %q : %w", header.Name, errInvalidRoot)
+	}
+	switch header.Name {
+	case "", ".", "..":
+		return fmt.Errorf("invalid root path: %q : %w", header.Name, errInvalidRoot)
+	}
+	rootName := header.Name
+
+	// Get the platform-specific output path
+	rootOutputPath := fp.Clean(te.Path)
+	if err := validatePlatformPath(rootOutputPath); err != nil {
+		return err
+	}
+
+	// If the last element in the rootOutputPath (which is passed by the user) is a symlink do not follow it
+	// this makes it easier for users to reason about where files are getting extracted to even when the tar is not
+	// from a trusted source
+	//
+	// For example, if the user extracts a mutable link to a tar file (http://sometimesbad.tld/t.tar) and situationally
+	// it contains a folder, file, or symlink the outputs could hop around the user's file system. This is especially
+	// annoying since we allow symlinks to point anywhere a user might want them to.
+	switch header.Typeflag {
+	case tar.TypeDir:
+		// if this is the root directory, use it as the output path for remaining files
+		firstObjectWasDir = true
+		if err := te.extractDir(rootOutputPath); err != nil {
+			return err
+		}
+	case tar.TypeReg, tar.TypeSymlink:
+		// Check if the output path already exists, so we know whether we should
+		// create our output with that name, or if we should put the output inside
+		// a preexisting directory
+
+		rootIsExistingDirectory := false
+		// We do not follow links here
+		if stat, err := os.Lstat(rootOutputPath); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+		} else if stat.IsDir() {
+			rootIsExistingDirectory = true
+		}
+
+		outputPath := rootOutputPath
+		// If the root is a directory which already exists then put the file/symlink in the directory
+		if rootIsExistingDirectory {
+			// make sure the root has a valid name
+			if err := validatePathComponent(rootName); err != nil {
+				return err
+			}
+
+			// If the output path directory exists then put the file/symlink into the directory.
+			outputPath = fp.Join(rootOutputPath, rootName)
+		}
+
+		// If an object with the target name already exists overwrite it
+		if header.Typeflag == tar.TypeReg {
+			if err := te.extractFile(outputPath, tarReader); err != nil {
+				return err
+			}
+		} else if err := te.extractSymlink(outputPath, header); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unrecognized tar header type: %d", header.Typeflag)
+	}
+
+	// files come recursively in order
+	for {
+		header, err := tarReader.Next()
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if header == nil || err == io.EOF {
+			break
+		}
+
+		// Make sure that we only have a single root element
+		if !firstObjectWasDir {
+			return fmt.Errorf("the root was not a directory and the tar has multiple entries: %w", errInvalidRoot)
+		}
+
+		// validate the path to remove paths we refuse to work with and make it easier to reason about
+		if err := validateTarPath(header.Name); err != nil {
+			return err
+		}
+		cleanedPath := header.Name
+
+		relPath, err := getRelativePath(rootName, cleanedPath)
+		if err != nil {
+			return err
+		}
+
+		outputPath, err := te.outputPath(rootOutputPath, relPath)
+		if err != nil {
+			return err
+		}
+
+		// This check should already be covered by previous validation, but may catch bugs that slip through.
+		// Checks if the relative path matches or exceeds the root
+		// We check for matching because the outputPath function strips the original root
+		rel, err := fp.Rel(rootOutputPath, outputPath)
+		if err != nil || rel == "." {
+			return errInvalidRootMultipleRoots
+		}
+		for _, e := range strings.Split(fp.ToSlash(rel), "/") {
+			if e == ".." {
+				return fmt.Errorf("relative path contains '..'")
+			}
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := te.extractDir(outputPath); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := te.extractFile(outputPath, tarReader); err != nil {
+				return err
+			}
+		case tar.TypeSymlink:
+			if err := te.extractSymlink(outputPath, header); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unrecognized tar header type: %d", header.Typeflag)
+		}
+	}
+	return nil
+}
+
+// validateTarPath returns an error if the path has problematic characters
+func validateTarPath(tarPath string) error {
+	if len(tarPath) == 0 {
+		return fmt.Errorf("path is empty")
+	}
+
+	if tarPath[0] == '/' {
+		return fmt.Errorf("%q : path starts with '/'", tarPath)
+	}
+
+	elems := strings.Split(tarPath, "/") // break into elems
+	for _, e := range elems {
+		switch e {
+		case "", ".", "..":
+			return fmt.Errorf("%q : path contains %q", tarPath, e)
+		}
+	}
+	return nil
+}
+
+// getRelativePath returns the relative path between rootTarPath and tarPath. Assumes both paths have been cleaned.
+// Will error if the tarPath is not below the rootTarPath.
+func getRelativePath(rootName, tarPath string) (string, error) {
+	if !strings.HasPrefix(tarPath, rootName+"/") {
+		return "", errInvalidRootMultipleRoots
+	}
+	return tarPath[len(rootName)+1:], nil
+}
+
+// outputPath returns the directory path at which to place the file relativeTarPath. Assumes relativeTarPath is cleaned.
+func (te *Extractor) outputPath(basePlatformPath, relativeTarPath string) (string, error) {
+	elems := strings.Split(relativeTarPath, "/")
+
+	platformPath := basePlatformPath
+	for i, e := range elems {
+		if err := validatePathComponent(e); err != nil {
+			return "", err
+		}
+		platformPath = fp.Join(platformPath, e)
+
+		// Last element is not checked since it will be removed (if it exists) by any of the extraction functions.
+		// For more details see:
+		// https://github.com/libarchive/libarchive/blob/0fd2ed25d78e9f4505de5dcb6208c6c0ff8d2edb/libarchive/archive_write_disk_posix.c#L2810
+		if i == len(elems)-1 {
+			break
+		}
+
+		fi, err := os.Lstat(platformPath)
+		if err != nil {
+			return "", err
+		}
+
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return "", errTraverseSymlink
+		}
+		if !fi.Mode().IsDir() {
+			return "", errors.New("cannot traverse non-directory objects")
+		}
+	}
+
+	return platformPath, nil
+}
+
+var errExtractedDirToSymlink = errors.New("cannot extract to symlink")
+
+func (te *Extractor) extractDir(path string) error {
+	err := os.MkdirAll(path, 0755)
+	if err != nil {
+		return err
+	}
+
+	if stat, err := os.Lstat(path); err != nil {
+		return err
+	} else if !stat.IsDir() {
+		return errExtractedDirToSymlink
+	}
+	return nil
+}
+
+func (te *Extractor) extractSymlink(path string, h *tar.Header) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	return os.Symlink(h.Linkname, path)
+}
+
+func (te *Extractor) extractFile(path string, r *tar.Reader) error {
+	// Attempt removing the target so we can overwrite files, symlinks and empty directories
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	// Create a temporary file in the target directory and then rename the temporary file to the target to better deal
+	// with races on the file system.
+	base := fp.Dir(path)
+	tmpfile, err := os.CreateTemp(base, "")
+	if err != nil {
+		return err
+	}
+	if err := copyWithProgress(tmpfile, r, te.Progress); err != nil {
+		_ = tmpfile.Close()
+		_ = os.Remove(tmpfile.Name())
+		return err
+	}
+	if err := tmpfile.Close(); err != nil {
+		_ = os.Remove(tmpfile.Name())
+		return err
+	}
+
+	if err := os.Rename(tmpfile.Name(), path); err != nil {
+		_ = os.Remove(tmpfile.Name())
+		return err
+	}
+
+	return nil
+}
+
+func copyWithProgress(to io.Writer, from io.Reader, cb func(int64) int64) error {
+	buf := make([]byte, 4096)
+	for {
+		n, err := from.Read(buf)
+		if n != 0 {
+			if cb != nil {
+				cb(int64(n))
+			}
+			_, err2 := to.Write(buf[:n])
+			if err2 != nil {
+				return err2
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+}

--- a/utils/tar/extractor_test.go
+++ b/utils/tar/extractor_test.go
@@ -1,0 +1,437 @@
+package tar
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	fp "path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var symlinksEnabled bool
+var symlinksEnabledErr error
+
+func init() {
+	// check if the platform supports symlinks
+	// inspired by https://github.com/golang/go/blob/770f1de8c54256d5b17447028e47b201ba8e62c8/src/internal/testenv/testenv_windows.go#L17
+
+	tmpdir, err := os.MkdirTemp("", "platformsymtest")
+	if err != nil {
+		panic("failed to create temp directory: " + err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	symlinksEnabledErr = os.Symlink("target", fp.Join(tmpdir, "symlink"))
+	symlinksEnabled = symlinksEnabledErr == nil
+
+	if !symlinksEnabled {
+		// for now assume symlinks only fail on Windows, Android and Plan9
+		// taken from https://github.com/golang/go/blob/770f1de8c54256d5b17447028e47b201ba8e62c8/src/internal/testenv/testenv_notwin.go#L14
+		// and https://github.com/golang/go/blob/770f1de8c54256d5b17447028e47b201ba8e62c8/src/internal/testenv/testenv_windows.go#L34
+		switch runtime.GOOS {
+		case "windows", "android", "plan9":
+		default:
+			panic(fmt.Errorf("attempted symlink creation failed: %w", symlinksEnabledErr))
+		}
+	}
+}
+
+func TestSingleFile(t *testing.T) {
+	fileName := "file..ext"
+	fileData := "file data"
+
+	testTarExtraction(t, nil, []tarEntry{
+		&fileTarEntry{fileName, []byte(fileData)},
+	},
+		func(t *testing.T, extractDir string) {
+			f, err := os.Open(fp.Join(extractDir, fileName))
+			assert.NoError(t, err)
+			data, err := io.ReadAll(f)
+			assert.NoError(t, err)
+			assert.Equal(t, fileData, string(data))
+			assert.NoError(t, f.Close())
+		},
+		nil,
+	)
+}
+
+func TestSingleDirectory(t *testing.T) {
+	dirName := "dir..sfx"
+
+	testTarExtraction(t, nil, []tarEntry{
+		&dirTarEntry{dirName},
+	},
+		func(t *testing.T, extractDir string) {
+			f, err := os.Open(extractDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			objs, err := f.Readdir(1)
+			if err == io.EOF && len(objs) == 0 {
+				return
+			}
+			t.Fatalf("expected an empty directory")
+		},
+		nil,
+	)
+}
+
+func TestDirectoryFollowSymlinkToNothing(t *testing.T) {
+	dirName := "dir"
+	childName := "child"
+
+	entries := []tarEntry{
+		&dirTarEntry{dirName},
+		&dirTarEntry{dirName + "/" + childName},
+	}
+
+	testTarExtraction(t, func(t *testing.T, rootDir string) {
+		target := fp.Join(rootDir, tarOutRoot)
+		if err := os.Symlink(fp.Join(target, "foo"), fp.Join(target, childName)); err != nil {
+			t.Fatal(err)
+		}
+	}, entries, nil,
+		os.ErrExist,
+	)
+}
+
+func TestDirectoryFollowSymlinkToFile(t *testing.T) {
+	dirName := "dir"
+	childName := "child"
+
+	entries := []tarEntry{
+		&dirTarEntry{dirName},
+		&dirTarEntry{dirName + "/" + childName},
+	}
+
+	testTarExtraction(t, func(t *testing.T, rootDir string) {
+		target := fp.Join(rootDir, tarOutRoot)
+		symlinkTarget := fp.Join(target, "foo")
+		if err := os.WriteFile(symlinkTarget, []byte("original data"), os.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(symlinkTarget, fp.Join(target, childName)); err != nil {
+			t.Fatal(err)
+		}
+	}, entries, nil,
+		syscall.ENOTDIR,
+	)
+}
+
+func TestDirectoryFollowSymlinkToDirectory(t *testing.T) {
+	dirName := "dir"
+	childName := "child"
+
+	entries := []tarEntry{
+		&dirTarEntry{dirName},
+		&dirTarEntry{dirName + "/" + childName},
+	}
+
+	testTarExtraction(t, func(t *testing.T, rootDir string) {
+		target := fp.Join(rootDir, tarOutRoot)
+		symlinkTarget := fp.Join(target, "foo")
+		if err := os.Mkdir(symlinkTarget, os.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(symlinkTarget, fp.Join(target, childName)); err != nil {
+			t.Fatal(err)
+		}
+	}, entries, nil,
+		errExtractedDirToSymlink,
+	)
+}
+
+func TestSingleSymlink(t *testing.T) {
+	if !symlinksEnabled {
+		t.Skip("symlinks disabled on this platform", symlinksEnabledErr)
+	}
+
+	targetName := "file"
+	symlinkName := "symlink"
+
+	testTarExtraction(t, nil, []tarEntry{
+		&symlinkTarEntry{targetName, symlinkName},
+	}, func(t *testing.T, extractDir string) {
+		symlinkPath := fp.Join(extractDir, symlinkName)
+		fi, err := os.Lstat(symlinkPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, fi.Mode()&os.ModeSymlink != 0, true, "expected to be a symlink")
+		targetPath, err := os.Readlink(symlinkPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, targetName, targetPath)
+	}, nil)
+}
+
+func TestMultipleRoots(t *testing.T) {
+	testTarExtraction(t, nil, []tarEntry{
+		&dirTarEntry{"root"},
+		&dirTarEntry{"sibling"},
+	}, nil, errInvalidRoot)
+}
+
+func TestMultipleRootsNested(t *testing.T) {
+	testTarExtraction(t, nil, []tarEntry{
+		&dirTarEntry{"root/child1"},
+		&dirTarEntry{"root/child2"},
+	}, nil, errInvalidRoot)
+}
+
+func TestOutOfOrderRoot(t *testing.T) {
+	testTarExtraction(t, nil, []tarEntry{
+		&dirTarEntry{"root/child"},
+		&dirTarEntry{"root"},
+	}, nil, errInvalidRoot)
+}
+
+func TestOutOfOrder(t *testing.T) {
+	testTarExtraction(t, nil, []tarEntry{
+		&dirTarEntry{"root/child/grandchild"},
+		&dirTarEntry{"root/child"},
+	}, nil, errInvalidRoot)
+}
+
+func TestNestedDirectories(t *testing.T) {
+	testTarExtraction(t, nil, []tarEntry{
+		&dirTarEntry{"root"},
+		&dirTarEntry{"root/child"},
+		&dirTarEntry{"root/child/grandchild"},
+	}, func(t *testing.T, extractDir string) {
+		walkIndex := 0
+		err := fp.Walk(extractDir,
+			func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				switch walkIndex {
+				case 0:
+					assert.Equal(t, info.Name(), tarOutRoot)
+				case 1:
+					assert.Equal(t, info.Name(), "child")
+				case 2:
+					assert.Equal(t, info.Name(), "grandchild")
+				default:
+					assert.Fail(t, "has more than 3 entries", path)
+				}
+				walkIndex++
+				return nil
+			})
+		assert.NoError(t, err)
+	}, nil)
+}
+
+func TestRootDirectoryHasSubpath(t *testing.T) {
+	testTarExtraction(t, nil, []tarEntry{
+		&dirTarEntry{"root/child"},
+		&dirTarEntry{"root/child/grandchild"},
+	}, nil, errInvalidRoot)
+}
+
+func TestFilesAndFolders(t *testing.T) {
+	testTarExtraction(t, nil, []tarEntry{
+		&dirTarEntry{"root"},
+		&dirTarEntry{"root/childdir"},
+		&fileTarEntry{"root/childdir/file1", []byte("some data")},
+	}, nil, nil)
+}
+
+func TestInternalSymlinkTraverse(t *testing.T) {
+	if !symlinksEnabled {
+		t.Skip("symlinks disabled on this platform", symlinksEnabledErr)
+	}
+	testTarExtraction(t, nil, []tarEntry{
+		// FIXME: We are ignoring the first element in the path check so
+		//  we add a directory at the start to bypass this.
+		&dirTarEntry{"root"},
+		&dirTarEntry{"root/child"},
+		&symlinkTarEntry{"child", "root/symlink-dir"},
+		&fileTarEntry{"root/symlink-dir/file", []byte("file")},
+	},
+		nil,
+		errTraverseSymlink,
+	)
+}
+
+func TestExternalSymlinkTraverse(t *testing.T) {
+	if !symlinksEnabled {
+		t.Skip("symlinks disabled on this platform", symlinksEnabledErr)
+	}
+	testTarExtraction(t, nil, []tarEntry{
+		// FIXME: We are ignoring the first element in the path check so
+		//  we add a directory at the start to bypass this.
+		&dirTarEntry{"inner"},
+		&symlinkTarEntry{"..", "inner/symlink-dir"},
+		&fileTarEntry{"inner/symlink-dir/file", []byte("overwrite content")},
+	},
+		nil,
+		errTraverseSymlink,
+	)
+}
+
+func TestLastElementOverwrite(t *testing.T) {
+	if !symlinksEnabled {
+		t.Skip("symlinks disabled on this platform", symlinksEnabledErr)
+	}
+	const originalData = "original"
+	testTarExtraction(t, func(t *testing.T, rootDir string) {
+		// Create an outside target that will try to be overwritten.
+		// This file will reside outside of the extraction directory root.
+		f, err := os.Create(fp.Join(rootDir, "outside-ref"))
+		assert.NoError(t, err)
+		n, err := f.WriteString(originalData)
+		assert.NoError(t, err)
+		assert.Equal(t, len(originalData), n)
+	},
+		[]tarEntry{
+			&dirTarEntry{"root"},
+			&symlinkTarEntry{"../outside-ref", "root/symlink"},
+			&fileTarEntry{"root/symlink", []byte("overwrite content")},
+		},
+		func(t *testing.T, extractDir string) {
+			// Check that outside-ref still exists but has not been
+			// overwritten or truncated (still size the same).
+			info, err := os.Stat(fp.Join(extractDir, "..", "outside-ref"))
+			assert.NoError(t, err)
+
+			assert.Equal(t, len(originalData), int(info.Size()), "outside reference has been overwritten")
+		},
+		nil,
+	)
+}
+
+const tarOutRoot = "tar-out-root"
+
+func testTarExtraction(t *testing.T, setup func(t *testing.T, rootDir string), tarEntries []tarEntry, check func(t *testing.T, extractDir string), extractError error) {
+	var err error
+
+	// Directory structure.
+	// FIXME: We can't easily work on a MemFS since we would need to replace
+	//  all the `os` calls in the extractor so using a temporary dir.
+	rootDir, err := os.MkdirTemp("", "tar-extraction-test")
+	assert.NoError(t, err)
+	extractDir := fp.Join(rootDir, tarOutRoot)
+	err = os.MkdirAll(extractDir, 0755)
+	assert.NoError(t, err)
+
+	// Generated TAR file.
+	tarFilename := fp.Join(rootDir, "generated.tar")
+	tarFile, err := os.Create(tarFilename)
+	assert.NoError(t, err)
+	defer tarFile.Close()
+	tw := tar.NewWriter(tarFile)
+	defer tw.Close()
+
+	if setup != nil {
+		setup(t, rootDir)
+	}
+
+	writeTarFile(t, tarFilename, tarEntries)
+
+	testExtract(t, tarFilename, extractDir, extractError)
+
+	if check != nil {
+		check(t, extractDir)
+	}
+}
+
+func testExtract(t *testing.T, tarFile string, extractDir string, expectedError error) {
+	var err error
+
+	tarReader, err := os.Open(tarFile)
+	assert.NoError(t, err)
+
+	extractor := &Extractor{Path: extractDir}
+	err = extractor.Extract(tarReader)
+
+	assert.ErrorIs(t, err, expectedError)
+}
+
+// Based on the `writeXXXHeader` family of functions in
+// github.com/ipfs/go-ipfs-files@v0.0.8/tarwriter.go.
+func writeTarFile(t *testing.T, path string, entries []tarEntry) {
+	tarFile, err := os.Create(path)
+	assert.NoError(t, err)
+	defer tarFile.Close()
+
+	tw := tar.NewWriter(tarFile)
+	defer tw.Close()
+
+	for _, e := range entries {
+		err = e.write(tw)
+		assert.NoError(t, err)
+	}
+}
+
+type tarEntry interface {
+	write(tw *tar.Writer) error
+}
+
+var _ tarEntry = (*fileTarEntry)(nil)
+var _ tarEntry = (*dirTarEntry)(nil)
+var _ tarEntry = (*symlinkTarEntry)(nil)
+
+type fileTarEntry struct {
+	path string
+	buf  []byte
+}
+
+func (e *fileTarEntry) write(tw *tar.Writer) error {
+	if err := writeFileHeader(tw, e.path, uint64(len(e.buf))); err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(tw, bytes.NewReader(e.buf)); err != nil {
+		return err
+	}
+
+	tw.Flush()
+	return nil
+}
+func writeFileHeader(w *tar.Writer, fpath string, size uint64) error {
+	return w.WriteHeader(&tar.Header{
+		Name:     fpath,
+		Size:     int64(size),
+		Typeflag: tar.TypeReg,
+		Mode:     0644,
+		ModTime:  time.Now(),
+		// TODO: set mode, dates, etc. when added to unixFS
+	})
+}
+
+type dirTarEntry struct {
+	path string
+}
+
+func (e *dirTarEntry) write(tw *tar.Writer) error {
+	return tw.WriteHeader(&tar.Header{
+		Name:     e.path,
+		Typeflag: tar.TypeDir,
+		Mode:     0777,
+		ModTime:  time.Now(),
+		// TODO: set mode, dates, etc. when added to unixFS
+	})
+}
+
+type symlinkTarEntry struct {
+	target string
+	path   string
+}
+
+func (e *symlinkTarEntry) write(w *tar.Writer) error {
+	return w.WriteHeader(&tar.Header{
+		Name:     e.path,
+		Linkname: e.target,
+		Mode:     0777,
+		Typeflag: tar.TypeSymlink,
+	})
+}

--- a/utils/tar/sanitize.go
+++ b/utils/tar/sanitize.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package tar
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func isNullDevice(path string) bool {
+	return path == os.DevNull
+}
+
+func validatePlatformPath(platformPath string) error {
+	if strings.Contains(platformPath, "\x00") {
+		return fmt.Errorf("invalid platform path: path components cannot contain null: %q", platformPath)
+	}
+	return nil
+}
+
+func validatePathComponent(c string) error {
+	if c == ".." {
+		return fmt.Errorf("invalid platform path: path component cannot be '..'")
+	}
+	if strings.Contains(c, "\x00") {
+		return fmt.Errorf("invalid platform path: path components cannot contain null: %q", c)
+	}
+	return nil
+}

--- a/utils/tar/sanitize_windows.go
+++ b/utils/tar/sanitize_windows.go
@@ -1,0 +1,74 @@
+package tar
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+var reservedNames = [...]string{"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"}
+
+const reservedCharsStr = `[<>:"\|?*]` + "\x00" //NOTE: `/` is not included as it is our standard path separator
+
+func isNullDevice(path string) bool {
+	// This is a case insensitive comparison to NUL
+	if len(path) != 3 {
+		return false
+	}
+	if path[0]|0x20 != 'n' {
+		return false
+	}
+	if path[1]|0x20 != 'u' {
+		return false
+	}
+	if path[2]|0x20 != 'l' {
+		return false
+	}
+	return true
+}
+
+// validatePathComponent returns an error if the given path component is not allowed on the platform
+func validatePathComponent(c string) error {
+	//MSDN: Do not end a file or directory name with a space or a period
+	if strings.HasSuffix(c, ".") {
+		return fmt.Errorf("invalid platform path: path components cannot end with '.' : %q", c)
+	}
+	if strings.HasSuffix(c, " ") {
+		return fmt.Errorf("invalid platform path: path components cannot end with ' ' : %q", c)
+	}
+
+	if c == ".." {
+		return fmt.Errorf("invalid platform path: path component cannot be '..'")
+	}
+	// error on reserved characters
+	if strings.ContainsAny(c, reservedCharsStr) {
+		return fmt.Errorf("invalid platform path: path components cannot contain any of %s : %q", reservedCharsStr, c)
+	}
+
+	// error on reserved names
+	for _, rn := range reservedNames {
+		if c == rn {
+			return fmt.Errorf("invalid platform path: path component is a reserved name: %s", c)
+		}
+	}
+
+	return nil
+}
+
+func validatePlatformPath(platformPath string) error {
+	// remove the volume name
+	p := platformPath[len(filepath.VolumeName(platformPath)):]
+
+	// convert to cleaned slash-path
+	p = filepath.ToSlash(p)
+	p = strings.Trim(p, "/")
+
+	// make sure all components of the path are valid
+	for _, e := range strings.Split(p, "/") {
+		if err := validatePathComponent(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This is my first attempt at this so let me know if there's something I can improve. I'm trying to refine the process and scripts for doing this. Basically I just applied the following script:

https://github.com/guseggert/repo-migration-tools/blob/ed8f3229d30a59558afbdc98ec0f016d9b1a3f77/migrate.sh#L29

and ran it with the following command:

```
~/git/repo-migration-tools/migrate.sh move-glob-to-subdir ~/git/tar-utils master '*.go' ~/git/libkubo migrate-tar-utils tar
```

I picked `tar-utils` because it is small and nothing else depends on it. I'll do something really meaty on the next iteration to stress-test this process.

Steps after merging this would be be to plumb this into Kubo and remove `github.com/ipfs/tar-utils` as a Kubo dependency, transfer any issues from `ipfs/tar-utils`, triage open PRs and see if any need to be transferred (with a bias towards not transferring), then archive the repo. In some cases we may want to stub out the exported types but I don't think that's necessary for `tar-utils`.